### PR TITLE
Support ES 1.5.0

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -12,7 +12,8 @@ Tokenizer: `ik`
 
 Version
 -------------
- master                      | 1.4.0 -> master
+ master                      | 1.5.0 -> master
+ 1.3.0                       | 1.5.0
  1.2.9                       | 1.4.0
  1.2.8                       | 1.3.2
  1.2.7                       | 1.2.1
@@ -247,3 +248,11 @@ have fun.
 -------------
 1.自定义词典为什么没有生效？
 请确保你的扩展词典的文本格式为UTF8编码
+
+2.如何手动安装，以 1.3.0 為例？（参考：https://github.com/medcl/elasticsearch-analysis-ik/issues/46）
+
+`git clone https://github.com/medcl/elasticsearch-analysis-ik`
+`cd elasticsearch-analysis-ik`
+`mvn compile`
+`mvn package`
+`plugin --install analysis-ik --url file:///#{project_path}/elasticsearch-analysis-ik/target/releases/elasticsearch-analysis-ik-1.3.0.zip`

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,14 @@
                     <descriptors>
                         <descriptor>${basedir}/src/main/assemblies/plugin.xml</descriptor>
                     </descriptors>
+                    <archive>
+                        <manifest>
+                            <mainClass>fully.qualified.MainClass</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
 	     <groupId>org.apache.httpcomponents</groupId>
               <artifactId>httpclient</artifactId>
-	     <version>4.3.5</version>
+	     <version>4.4.1</version>
 	</dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-ik</artifactId>
-    <version>1.2.9</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
     <description>IK Analyzer for ElasticSearch</description>
     <inceptionYear>2009</inceptionYear>
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>1.4.0</elasticsearch.version>
+        <elasticsearch.version>1.5.0</elasticsearch.version>
     </properties>
 
   <repositories>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>4.9.0</version>
+            <version>4.10.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Changes

* Support Elasticsearch to 1.5.0
* Upgrade Lucene to 4.10.4
* Upgrade http-component to 4.4.1
* Update README for version changes and how to manually install compiled plugin