### PR TITLE
1、将http 304作为正常状态处理；2、应为ETag，而不是ETags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>1.6.0</elasticsearch.version>
+        <elasticsearch.version>1.6.2</elasticsearch.version>
     </properties>
 
   <repositories>

--- a/src/main/java/org/wltea/analyzer/dic/Monitor.java
+++ b/src/main/java/org/wltea/analyzer/dic/Monitor.java
@@ -62,15 +62,15 @@ public class Monitor implements Runnable {
 			response = httpclient.execute(head);
 			
 			//返回200 才做操作
-			if(response.getStatusLine().getStatusCode()==200){
+			if(response.getStatusLine().getStatusCode()==200 || response.getStatusLine().getStatusCode()==304){
 			
 				if (!response.getLastHeader("Last-Modified").getValue().equalsIgnoreCase(last_modified)
-					||!response.getLastHeader("ETags").getValue().equalsIgnoreCase(eTags)) {
+					||!response.getLastHeader("ETag").getValue().equalsIgnoreCase(eTags)) {
 
 					// 远程词库有更新,需要重新加载词典，并修改last_modified,eTags
 					Dictionary.getSingleton().reLoadMainDict();
 					last_modified = response.getLastHeader("Last-Modified")==null?null:response.getLastHeader("Last-Modified").getValue();
-					eTags = response.getLastHeader("ETags")==null?null:response.getLastHeader("ETags").getValue();
+					eTags = response.getLastHeader("ETag")==null?null:response.getLastHeader("ETag").getValue();
 				}
 			}else{
 				Dictionary.logger.info("remote_ext_dict {} return bad code {}" , location , response.getStatusLine().getStatusCode() );


### PR DESCRIPTION
1、将http 304作为正常状态处理，避免大量304错误写到日志文件里；2、应为ETag，而不是ETags