### PR TITLE
检测词元位置交叉代码优化

### DIFF
--- a/src/main/java/org/wltea/analyzer/core/LexemePath.java
+++ b/src/main/java/org/wltea/analyzer/core/LexemePath.java
@@ -122,8 +122,10 @@ class LexemePath extends QuickSortSet implements Comparable<LexemePath>{
 	 * @return
 	 */
 	boolean checkCross(Lexeme lexeme){
-		return (lexeme.getBegin() >= this.pathBegin && lexeme.getBegin() < this.pathEnd)
-				|| (this.pathBegin >= lexeme.getBegin() && this.pathBegin < lexeme.getBegin()+ lexeme.getLength());
+		int start = this.getPathBegin() < lexeme.getBeginPosition() ? this.getPathBegin() : lexeme.getBegin();
+		int end = this.getPathEnd() > lexeme.getEndPosition() ? this.getPathEnd() : lexeme.getEndPosition();
+
+		return (end - start) <= (this.getPathLength() + lexeme.getLength());
 	}
 	
 	int getPathBegin() {


### PR DESCRIPTION
如上
最近在拜读ik源码，发现检测词元位置交叉的地方有点问题，顺手改了下，请看下是否有用