### PR TITLE
Fixing the use of inefficient Number Constructor and Double check

### DIFF
--- a/src/main/java/org/wltea/analyzer/dic/DictSegment.java
+++ b/src/main/java/org/wltea/analyzer/dic/DictSegment.java
@@ -115,7 +115,7 @@ class DictSegment implements Comparable<DictSegment>{
 		//设置hit的当前处理位置
 		searchHit.setEnd(begin);
 
-        Character keyChar = new Character(charArray[begin]);
+        Character keyChar = Character.valueOf(charArray[begin]);
 		DictSegment ds = null;
 		
 		//引用实例变量为本地变量，避免查询时遇到更新的同步问题
@@ -187,7 +187,7 @@ class DictSegment implements Comparable<DictSegment>{
 	 */
 	private synchronized void fillSegment(char[] charArray , int begin , int length , int enabled){
 		//获取字典表中的汉字对象
-		Character beginChar = new Character(charArray[begin]);
+		Character beginChar = Character.valueOf(charArray[begin]);
 		Character keyChar = charMap.get(beginChar);
 		//字典中没有该字，则将其添加入字典
 		if(keyChar == null){
@@ -280,11 +280,9 @@ class DictSegment implements Comparable<DictSegment>{
 	 * 线程同步方法
 	 */
 	private DictSegment[] getChildrenArray(){
-		if(this.childrenArray == null){
-			synchronized(this){
-				if(this.childrenArray == null){
+		synchronized(this){
+			if(this.childrenArray == null){
 					this.childrenArray = new DictSegment[ARRAY_LENGTH_LIMIT];
-				}
 			}
 		}
 		return this.childrenArray;
@@ -295,11 +293,9 @@ class DictSegment implements Comparable<DictSegment>{
 	 * 线程同步方法
 	 */	
 	private Map<Character , DictSegment> getChildrenMap(){
-		if(this.childrenMap == null){
-			synchronized(this){
-				if(this.childrenMap == null){
-					this.childrenMap = new ConcurrentHashMap<Character, DictSegment>(ARRAY_LENGTH_LIMIT * 2,0.8f);
-				}
+		synchronized(this){
+			if(this.childrenMap == null){
+				this.childrenMap = new ConcurrentHashMap<Character, DictSegment>(ARRAY_LENGTH_LIMIT * 2,0.8f);
 			}
 		}
 		return this.childrenMap;

--- a/src/main/java/org/wltea/analyzer/dic/Dictionary.java
+++ b/src/main/java/org/wltea/analyzer/dic/Dictionary.java
@@ -103,29 +103,28 @@ public class Dictionary {
 	 * @return Dictionary
 	 */
 	public static synchronized Dictionary initial(Configuration cfg){
-		if(singleton == null){
-			synchronized(Dictionary.class){
-				if(singleton == null){
-					singleton = new Dictionary();
-                    singleton.configuration=cfg;
-                    singleton.loadMainDict();
-                    singleton.loadSurnameDict();
-                    singleton.loadQuantifierDict();
-                    singleton.loadSuffixDict();
-                    singleton.loadPrepDict();
-                    singleton.loadStopWordDict();
-                    
-	                //建立监控线程
-	                for(String location:cfg.getRemoteExtDictionarys()){
-	                	//10 秒是初始延迟可以修改的  60是间隔时间  单位秒
-	            		pool.scheduleAtFixedRate(new Monitor(location), 10, 60, TimeUnit.SECONDS);
-	                }
-	                for(String location:cfg.getRemoteExtStopWordDictionarys()){
-	            		pool.scheduleAtFixedRate(new Monitor(location), 10, 60, TimeUnit.SECONDS);
-	                }
-	                    
-	                return singleton;
+		
+		synchronized(Dictionary.class){
+			if(singleton == null){
+				singleton = new Dictionary();
+				singleton.configuration=cfg;
+				singleton.loadMainDict();
+				singleton.loadSurnameDict();
+				singleton.loadQuantifierDict();
+				singleton.loadSuffixDict();
+				singleton.loadPrepDict();
+				singleton.loadStopWordDict();
+				
+				//建立监控线程
+				for(String location:cfg.getRemoteExtDictionarys()){
+					//10 秒是初始延迟可以修改的  60是间隔时间  单位秒
+					pool.scheduleAtFixedRate(new Monitor(location), 10, 60, TimeUnit.SECONDS);
 				}
+				for(String location:cfg.getRemoteExtStopWordDictionarys()){
+					pool.scheduleAtFixedRate(new Monitor(location), 10, 60, TimeUnit.SECONDS);
+				}
+				
+				return singleton;
 			}
 		}
 		return singleton;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Findbugs rules:
DM_NUMBER_CTOR - “ Method invokes inefficient Number constructor; use static valueOf instead ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#DM_NUMBER_CTOR
And
DC_DOUBLECHECK - “ Possible double check of field ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#DC_DOUBLECHECK
Please let me know if you have any questions.
Ayman Abdelghany.