### PR TITLE
Casting math operands before assignment

### DIFF
--- a/src/main/java/org/wltea/analyzer/help/Sleep.java
+++ b/src/main/java/org/wltea/analyzer/help/Sleep.java
@@ -15,13 +15,13 @@ public class Sleep {
 					Thread.sleep(num);
 					return;
 				case SEC:
-					Thread.sleep(num*1000);
+					Thread.sleep(num*1000L);
 					return;
 				case MIN:
-					Thread.sleep(num*60*1000);
+					Thread.sleep(num*60*1000L);
 					return;
 				case HOUR:
-					Thread.sleep(num*60*60*1000);
+					Thread.sleep(num*60*60*1000L);
 					return;
 				default:
                     logger.error("输入类型错误，应为MSEC,SEC,MIN,HOUR之一");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2184 - “ Math operands should be cast before assignment”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
Ayman Abdelghany.