### PR TITLE
Update AnalyzeContext.java

### DIFF
--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -267,6 +267,15 @@ class AnalyzeContext {
 				Lexeme l = path.pollFirst();
 				while(l != null){
 					this.results.add(l);
+					//字典中无单字，但是词元冲突了，切分出相交词元的前一个词元中的单字
+					int innerIndex = index + 1;
+					for (; innerIndex < index + l.getLength(); innerIndex++) {
+						Lexeme innerL = path.peekFirst();
+						if (innerL != null && innerIndex == innerL.getBegin()) {
+							this.outputSingleCJK(innerIndex - 1);
+						}
+					}
+					
 					//将index移至lexeme后
 					index = l.getBegin() + l.getLength();					
 					l = path.pollFirst();


### PR DESCRIPTION
使用ik_smart切分 金力泰合同审批 切分的结果是（金  力  泰  合同  审批）但是使用ik_max_word切分结果是（金  力  泰合  合同  审批 批），这样就存在搜索（金力泰  金力泰合同审批） 搜索不到的情况，查看源码发现泰未在字典中，泰合  合同在字典中，导致smart切分消歧的时候按照逆向概率高的规则忽略了泰合，输出结果泰就单独切分了，可以在输出结果时判断下 字典中无单字，但是词元冲突了，切分出相交词元的前一个词元中的单字，这样就能解决这个问题