### PR TITLE
Correct Search Analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ curl -XPOST http://localhost:9200/index/_mapping -H 'Content-Type:application/js
             "content": {
                 "type": "text",
                 "analyzer": "ik_max_word",
-                "search_analyzer": "ik_max_word"
+                "search_analyzer": "ik_smart"
             }
         }
 


### PR DESCRIPTION
The former search analyzer `ik-max-word` will give the wrong result against described later in the README file.