### PR TITLE
independent remote dictionary support.

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/IkAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/IkAnalyzerProvider.java
@@ -12,7 +12,7 @@ public class IkAnalyzerProvider extends AbstractIndexAnalyzerProvider<IKAnalyzer
     public IkAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings,boolean useSmart) {
         super(indexSettings, name, settings);
 
-        Configuration configuration=new Configuration(env,settings).setUseSmart(useSmart);
+        Configuration configuration = new Configuration(env, settings, indexSettings.getIndex().getName()).setUseSmart(useSmart);
 
         analyzer=new IKAnalyzer(configuration);
     }

--- a/src/main/java/org/elasticsearch/index/analysis/IkTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/IkTokenizerFactory.java
@@ -12,7 +12,7 @@ public class IkTokenizerFactory extends AbstractTokenizerFactory {
 
   public IkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
       super(indexSettings, settings);
-	  configuration=new Configuration(env,settings);
+	  configuration=new Configuration(env,settings, indexSettings.getIndex().getName());
   }
 
   public static IkTokenizerFactory getIkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {

--- a/src/main/java/org/wltea/analyzer/cfg/Configuration.java
+++ b/src/main/java/org/wltea/analyzer/cfg/Configuration.java
@@ -27,9 +27,12 @@ public class Configuration {
 	//是否启用小写处理
 	private boolean enableLowercase=true;
 
+	private String indexName;
+
+	private Dictionary dictionary;
 
 	@Inject
-	public Configuration(Environment env,Settings settings) {
+	public Configuration(Environment env,Settings settings, String indexName) {
 		this.environment = env;
 		this.settings=settings;
 
@@ -37,9 +40,9 @@ public class Configuration {
 		this.enableLowercase = settings.get("enable_lowercase", "true").equals("true");
 		this.enableRemoteDict = settings.get("enable_remote_dict", "true").equals("true");
 
-		Dictionary.initial(this);
-
-	}
+        this.indexName = indexName;
+        this.dictionary = new Dictionary(this);
+    }
 
 	public Path getConfigInPluginDir() {
 		return PathUtils
@@ -72,4 +75,12 @@ public class Configuration {
 	public boolean isEnableLowercase() {
 		return enableLowercase;
 	}
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public Dictionary getDictionary() {
+        return dictionary;
+    }
 }

--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -322,7 +322,7 @@ class AnalyzeContext {
 		while(result != null){
     		//数量词合并
     		this.compound(result);
-    		if(Dictionary.getSingleton().isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
+    		if(cfg.getDictionary().isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
        			//是停止词继续取列表的下一个
     			result = this.results.pollFirst(); 				
     		}else{

--- a/src/main/java/org/wltea/analyzer/core/CJKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/CJKSegmenter.java
@@ -25,6 +25,7 @@
  */
 package org.wltea.analyzer.core;
 
+import org.wltea.analyzer.cfg.Configuration;
 import org.wltea.analyzer.dic.Dictionary;
 import org.wltea.analyzer.dic.Hit;
 
@@ -41,10 +42,11 @@ class CJKSegmenter implements ISegmenter {
 	static final String SEGMENTER_NAME = "CJK_SEGMENTER";
 	//待处理的分词hit队列
 	private List<Hit> tmpHits;
+	private Configuration configuration;
 	
-	
-	CJKSegmenter(){
+	CJKSegmenter(Configuration configuration){
 		this.tmpHits = new LinkedList<Hit>();
+		this.configuration = configuration;
 	}
 
 	/* (non-Javadoc)
@@ -58,7 +60,7 @@ class CJKSegmenter implements ISegmenter {
 				//处理词段队列
 				Hit[] tmpArray = this.tmpHits.toArray(new Hit[this.tmpHits.size()]);
 				for(Hit hit : tmpArray){
-					hit = Dictionary.getSingleton().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
+					hit = configuration.getDictionary().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
 					if(hit.isMatch()){
 						//输出当前的词
 						Lexeme newLexeme = new Lexeme(context.getBufferOffset() , hit.getBegin() , context.getCursor() - hit.getBegin() + 1 , Lexeme.TYPE_CNWORD);
@@ -77,7 +79,7 @@ class CJKSegmenter implements ISegmenter {
 			
 			//*********************************
 			//再对当前指针位置的字符进行单字匹配
-			Hit singleCharHit = Dictionary.getSingleton().matchInMainDict(context.getSegmentBuff(), context.getCursor(), 1);
+			Hit singleCharHit = configuration.getDictionary().matchInMainDict(context.getSegmentBuff(), context.getCursor(), 1);
 			if(singleCharHit.isMatch()){//首字成词
 				//输出当前的词
 				Lexeme newLexeme = new Lexeme(context.getBufferOffset() , context.getCursor() , 1 , Lexeme.TYPE_CNWORD);

--- a/src/main/java/org/wltea/analyzer/core/CN_QuantifierSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/CN_QuantifierSegmenter.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.wltea.analyzer.cfg.Configuration;
 import org.wltea.analyzer.dic.Dictionary;
 import org.wltea.analyzer.dic.Hit;
 
@@ -65,12 +66,15 @@ class CN_QuantifierSegmenter implements ISegmenter{
 
 	//待处理的量词hit队列
 	private List<Hit> countHits;
+
+	private Configuration configuration;
 	
 	
-	CN_QuantifierSegmenter(){
+	CN_QuantifierSegmenter(Configuration configuration){
 		nStart = -1;
 		nEnd = -1;
 		this.countHits  = new LinkedList<Hit>();
+		this.configuration = configuration;
 	}
 	
 	/**
@@ -153,7 +157,7 @@ class CN_QuantifierSegmenter implements ISegmenter{
 				//处理词段队列
 				Hit[] tmpArray = this.countHits.toArray(new Hit[this.countHits.size()]);
 				for(Hit hit : tmpArray){
-					hit = Dictionary.getSingleton().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
+					hit = configuration.getDictionary().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
 					if(hit.isMatch()){
 						//输出当前的词
 						Lexeme newLexeme = new Lexeme(context.getBufferOffset() , hit.getBegin() , context.getCursor() - hit.getBegin() + 1 , Lexeme.TYPE_COUNT);
@@ -172,7 +176,7 @@ class CN_QuantifierSegmenter implements ISegmenter{
 
 			//*********************************
 			//对当前指针位置的字符进行单字匹配
-			Hit singleCharHit = Dictionary.getSingleton().matchInQuantifierDict(context.getSegmentBuff(), context.getCursor(), 1);
+			Hit singleCharHit = configuration.getDictionary().matchInQuantifierDict(context.getSegmentBuff(), context.getCursor(), 1);
 			if(singleCharHit.isMatch()){//首字成量词词
 				//输出当前的词
 				Lexeme newLexeme = new Lexeme(context.getBufferOffset() , context.getCursor() , 1 , Lexeme.TYPE_COUNT);

--- a/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
@@ -79,9 +79,9 @@ public final class IKSegmenter {
 		//处理字母的子分词器
 		segmenters.add(new LetterSegmenter()); 
 		//处理中文数量词的子分词器
-		segmenters.add(new CN_QuantifierSegmenter());
+		segmenters.add(new CN_QuantifierSegmenter(configuration));
 		//处理中文词的子分词器
-		segmenters.add(new CJKSegmenter());
+		segmenters.add(new CJKSegmenter(configuration));
 		return segmenters;
 	}
 	

--- a/src/main/java/org/wltea/analyzer/dic/Monitor.java
+++ b/src/main/java/org/wltea/analyzer/dic/Monitor.java
@@ -32,10 +32,13 @@ public class Monitor implements Runnable {
 	 */
 	private String location;
 
-	public Monitor(String location) {
+	private Dictionary dictionary;
+
+	public Monitor(String location, Dictionary dictionary) {
 		this.location = location;
 		this.last_modified = null;
 		this.eTags = null;
+		this.dictionary = dictionary;
 	}
 
 	public void run() {
@@ -84,7 +87,7 @@ public class Monitor implements Runnable {
 						||((response.getLastHeader("ETag")!=null) && !response.getLastHeader("ETag").getValue().equalsIgnoreCase(eTags))) {
 
 					// 远程词库有更新,需要重新加载词典，并修改last_modified,eTags
-					Dictionary.getSingleton().reLoadMainDict();
+					this.dictionary.reLoadMainDict();
 					last_modified = response.getLastHeader("Last-Modified")==null?null:response.getLastHeader("Last-Modified").getValue();
 					eTags = response.getLastHeader("ETag")==null?null:response.getLastHeader("ETag").getValue();
 				}


### PR DESCRIPTION
支持每个索引使用不同的远程词典. 原remote_ext_dict 配置项变成一个前缀. 
eg: 存在两个索引 index1, index2; 用户配置了远程词典为 http://127.0.0.1:8080/dic
热词更新时，会分别从http://127.0.0.1:8080/dic/index1  和 http://127.0.0.1:8080/dic/index2拉取