### PR TITLE
add settings to enable/disable stopwords in analyzer

### DIFF
--- a/src/main/java/org/wltea/analyzer/cfg/Configuration.java
+++ b/src/main/java/org/wltea/analyzer/cfg/Configuration.java
@@ -21,6 +21,9 @@ public class Configuration {
 	//是否启用智能分词
 	private  boolean useSmart;
 
+	//是否使用停止词
+	private boolean useStopWords;
+
 	//是否启用远程词典加载
 	private boolean enableRemoteDict=false;
 
@@ -34,6 +37,7 @@ public class Configuration {
 		this.settings=settings;
 
 		this.useSmart = settings.get("use_smart", "false").equals("true");
+		this.useStopWords = settings.get("use_stopwords", "true").equals("true");
 		this.enableLowercase = settings.get("enable_lowercase", "true").equals("true");
 		this.enableRemoteDict = settings.get("enable_remote_dict", "true").equals("true");
 
@@ -50,6 +54,10 @@ public class Configuration {
 
 	public boolean isUseSmart() {
 		return useSmart;
+	}
+
+	public boolean isUseStopWords() {
+		return useStopWords;
 	}
 
 	public Configuration setUseSmart(boolean useSmart) {

--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -322,7 +322,7 @@ class AnalyzeContext {
 		while(result != null){
     		//数量词合并
     		this.compound(result);
-    		if(Dictionary.getSingleton().isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
+    		if(cfg.isUseStopWords() && Dictionary.getSingleton().isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
        			//是停止词继续取列表的下一个
     			result = this.results.pollFirst(); 				
     		}else{


### PR DESCRIPTION
In some cases, for some doc fields like project_name/table_name,  the stopwords are expected to be indexed and searchable. so would like to add a switch to disable stopwords. 