### PR TITLE
支持多个不同的远程词库

### DIFF
--- a/src/main/java/org/wltea/analyzer/cfg/Configuration.java
+++ b/src/main/java/org/wltea/analyzer/cfg/Configuration.java
@@ -23,6 +23,8 @@ public class Configuration {
 
 	//是否启用远程词典加载
 	private boolean enableRemoteDict=false;
+	//自定义词库名
+	private String remoteDictName="";
 
 	//是否启用小写处理
 	private boolean enableLowercase=true;
@@ -36,6 +38,7 @@ public class Configuration {
 		this.useSmart = settings.get("use_smart", "false").equals("true");
 		this.enableLowercase = settings.get("enable_lowercase", "true").equals("true");
 		this.enableRemoteDict = settings.get("enable_remote_dict", "true").equals("true");
+		this.remoteDictName = settings.get("custom_dict_name", "");
 
 		Dictionary.initial(this);
 
@@ -67,6 +70,9 @@ public class Configuration {
 
 	public boolean isEnableRemoteDict() {
 		return enableRemoteDict;
+	}
+	public String getRemoteDictName() {
+		return remoteDictName;
 	}
 
 	public boolean isEnableLowercase() {

--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -322,7 +322,7 @@ class AnalyzeContext {
 		while(result != null){
     		//数量词合并
     		this.compound(result);
-    		if(Dictionary.getSingleton().isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
+    		if(Dictionary.getDictionary(cfg.getRemoteDictName()).isStopWord(this.segmentBuff ,  result.getBegin() , result.getLength())){
        			//是停止词继续取列表的下一个
     			result = this.results.pollFirst(); 				
     		}else{

--- a/src/main/java/org/wltea/analyzer/core/CJKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/CJKSegmenter.java
@@ -25,6 +25,7 @@
  */
 package org.wltea.analyzer.core;
 
+import org.wltea.analyzer.cfg.Configuration;
 import org.wltea.analyzer.dic.Dictionary;
 import org.wltea.analyzer.dic.Hit;
 
@@ -39,12 +40,14 @@ class CJKSegmenter implements ISegmenter {
 	
 	//子分词器标签
 	static final String SEGMENTER_NAME = "CJK_SEGMENTER";
+	private final Configuration cfg;
 	//待处理的分词hit队列
 	private List<Hit> tmpHits;
 	
 	
-	CJKSegmenter(){
+	CJKSegmenter(Configuration cfg){
 		this.tmpHits = new LinkedList<Hit>();
+		this.cfg = cfg;
 	}
 
 	/* (non-Javadoc)
@@ -58,7 +61,7 @@ class CJKSegmenter implements ISegmenter {
 				//处理词段队列
 				Hit[] tmpArray = this.tmpHits.toArray(new Hit[this.tmpHits.size()]);
 				for(Hit hit : tmpArray){
-					hit = Dictionary.getSingleton().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
+					hit = Dictionary.getDictionary(cfg.getRemoteDictName()).matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
 					if(hit.isMatch()){
 						//输出当前的词
 						Lexeme newLexeme = new Lexeme(context.getBufferOffset() , hit.getBegin() , context.getCursor() - hit.getBegin() + 1 , Lexeme.TYPE_CNWORD);
@@ -77,7 +80,7 @@ class CJKSegmenter implements ISegmenter {
 			
 			//*********************************
 			//再对当前指针位置的字符进行单字匹配
-			Hit singleCharHit = Dictionary.getSingleton().matchInMainDict(context.getSegmentBuff(), context.getCursor(), 1);
+			Hit singleCharHit = Dictionary.getDictionary(cfg.getRemoteDictName()).matchInMainDict(context.getSegmentBuff(), context.getCursor(), 1);
 			if(singleCharHit.isMatch()){//首字成词
 				//输出当前的词
 				Lexeme newLexeme = new Lexeme(context.getBufferOffset() , context.getCursor() , 1 , Lexeme.TYPE_CNWORD);

--- a/src/main/java/org/wltea/analyzer/core/CN_QuantifierSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/CN_QuantifierSegmenter.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.wltea.analyzer.cfg.Configuration;
 import org.wltea.analyzer.dic.Dictionary;
 import org.wltea.analyzer.dic.Hit;
 
@@ -50,7 +51,9 @@ class CN_QuantifierSegmenter implements ISegmenter{
 			ChnNumberChars.add(nChar);
 		}
 	}
-	
+
+	private final Configuration cfg;
+
 	/*
 	 * 词元的开始位置，
 	 * 同时作为子分词器状态标识
@@ -67,10 +70,11 @@ class CN_QuantifierSegmenter implements ISegmenter{
 	private List<Hit> countHits;
 	
 	
-	CN_QuantifierSegmenter(){
+	CN_QuantifierSegmenter(Configuration cfg){
 		nStart = -1;
 		nEnd = -1;
 		this.countHits  = new LinkedList<Hit>();
+		this.cfg = cfg;
 	}
 	
 	/**
@@ -153,7 +157,7 @@ class CN_QuantifierSegmenter implements ISegmenter{
 				//处理词段队列
 				Hit[] tmpArray = this.countHits.toArray(new Hit[this.countHits.size()]);
 				for(Hit hit : tmpArray){
-					hit = Dictionary.getSingleton().matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
+					hit = Dictionary.getDictionary(cfg.getRemoteDictName()).matchWithHit(context.getSegmentBuff(), context.getCursor() , hit);
 					if(hit.isMatch()){
 						//输出当前的词
 						Lexeme newLexeme = new Lexeme(context.getBufferOffset() , hit.getBegin() , context.getCursor() - hit.getBegin() + 1 , Lexeme.TYPE_COUNT);
@@ -172,7 +176,7 @@ class CN_QuantifierSegmenter implements ISegmenter{
 
 			//*********************************
 			//对当前指针位置的字符进行单字匹配
-			Hit singleCharHit = Dictionary.getSingleton().matchInQuantifierDict(context.getSegmentBuff(), context.getCursor(), 1);
+			Hit singleCharHit = Dictionary.getDictionary(cfg.getRemoteDictName()).matchInQuantifierDict(context.getSegmentBuff(), context.getCursor(), 1);
 			if(singleCharHit.isMatch()){//首字成量词词
 				//输出当前的词
 				Lexeme newLexeme = new Lexeme(context.getBufferOffset() , context.getCursor() , 1 , Lexeme.TYPE_COUNT);

--- a/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
@@ -79,9 +79,9 @@ public final class IKSegmenter {
 		//处理字母的子分词器
 		segmenters.add(new LetterSegmenter()); 
 		//处理中文数量词的子分词器
-		segmenters.add(new CN_QuantifierSegmenter());
+		segmenters.add(new CN_QuantifierSegmenter(this.configuration));
 		//处理中文词的子分词器
-		segmenters.add(new CJKSegmenter());
+		segmenters.add(new CJKSegmenter(this.configuration));
 		return segmenters;
 	}
 	

--- a/src/main/java/org/wltea/analyzer/dic/Monitor.java
+++ b/src/main/java/org/wltea/analyzer/dic/Monitor.java
@@ -19,6 +19,10 @@ public class Monitor implements Runnable {
 
 	private static CloseableHttpClient httpclient = HttpClients.createDefault();
 	/*
+	 * 自定义词典名，默认为common
+	 */
+	private final String customRemoteDictName;
+	/*
 	 * 上次更改时间
 	 */
 	private String last_modified;
@@ -32,10 +36,11 @@ public class Monitor implements Runnable {
 	 */
 	private String location;
 
-	public Monitor(String location) {
+	public Monitor(String location, String customRemoteDictName) {
 		this.location = location;
 		this.last_modified = null;
 		this.eTags = null;
+		this.customRemoteDictName = customRemoteDictName;
 	}
 
 	public void run() {
@@ -84,7 +89,7 @@ public class Monitor implements Runnable {
 						||((response.getLastHeader("ETag")!=null) && !response.getLastHeader("ETag").getValue().equalsIgnoreCase(eTags))) {
 
 					// 远程词库有更新,需要重新加载词典，并修改last_modified,eTags
-					Dictionary.getSingleton().reLoadMainDict();
+					Dictionary.getDictionary(customRemoteDictName).reLoadMainDict();
 					last_modified = response.getLastHeader("Last-Modified")==null?null:response.getLastHeader("Last-Modified").getValue();
 					eTags = response.getLastHeader("ETag")==null?null:response.getLastHeader("ETag").getValue();
 				}


### PR DESCRIPTION
未指定custom_dict_name时，直接访问ik配置文件中的url
当指定custom_dict_name时，访问url/custom_dict_name

举例：
1. ik配置文件中指定词典url为：http://dict.xxx.com/dict，
   则默认访问的路径为http://dict.xxx.com/dict，
2. 当需要使用定制的词典路径时，则需要对ik分词器进行配置，参考：
```
PUT ik-test
{
    "settings": {
        "analysis.analyzer": {
            "custom_ik": {
                "type": "ik_smart",
                "enable_remote_dict": true,
                "custom_dict_name": "custom_dict"
            }
        }
    },
    "mappings": {
        "_doc": {
            "properties": {
                "field1": {
                    "type": "text",
                    "analyzer": "custom_ik"
                }
            }
        }
    }
}

POST ik-test/_analyze
{
    "field": "field1",
    "text": "脑暴最棒加一"
}
```
此配置下将会访问http://dict.xxx.com/dict/custom_dict 获取词库