### PR TITLE
fix(sec): upgrade httpclient to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade httpclient from 4.5.2 to 4.5.13 for vulnerability fix:
- [MPS-2022-12292](https://www.oscs1024.com/hd/MPS-2022-12292)
- [CVE-2020-13956](https://www.oscs1024.com/hd/MPS-2020-17341)