### PR TITLE
fix(offset): fix mistake offset due to end of useless chars

### DIFF
--- a/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -61,6 +61,8 @@ class AnalyzeContext {
     private int cursor;
     //最近一次读入的,可处理的字串长度
 	private int available;
+	//末尾非CJK字符数目
+	private int lastUselessCharNum;
 
 	
 	//子分词器锁
@@ -117,6 +119,7 @@ class AnalyzeContext {
     	if(this.buffOffset == 0){
     		//首次读取reader
     		readCount = reader.read(segmentBuff);
+			this.lastUselessCharNum = 0;
     	}else{
     		int offset = this.available - this.cursor;
     		if(offset > 0){
@@ -258,8 +261,11 @@ class AnalyzeContext {
 			//跳过非CJK字符
 			if(CharacterUtil.CHAR_USELESS == this.charTypes[index]){
 				index++;
+				this.lastUselessCharNum++;
 				continue;
 			}
+			// 清空数值
+			this.lastUselessCharNum = 0;
 			//从pathMap找出对应index位置的LexemePath
 			LexemePath path = this.pathMap.get(index);
 			if(path != null){
@@ -333,7 +339,14 @@ class AnalyzeContext {
 		}
 		return result;
 	}
-	
+
+	/**
+	 * 返回末尾非CJK字符字符数目
+	 */
+	public int getLastUselessCharNum(){
+		return this.lastUselessCharNum;
+	}
+
 	/**
 	 * 重置分词上下文状态
 	 */

--- a/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
+++ b/src/main/java/org/wltea/analyzer/core/IKSegmenter.java
@@ -144,4 +144,11 @@ public final class IKSegmenter {
 			segmenter.reset();
 		}
 	}
+
+	/**
+	 * 返回末尾非CJK字符字符数目
+	 */
+	public int getLastUselessCharNum() {
+		return this.context.getLastUselessCharNum();
+	}
 }

--- a/src/main/java/org/wltea/analyzer/lucene/IKTokenizer.java
+++ b/src/main/java/org/wltea/analyzer/lucene/IKTokenizer.java
@@ -117,13 +117,14 @@ public final class IKTokenizer extends Tokenizer {
 		super.reset();
 		_IKImplement.reset(input);
         skippedPositions = 0;
+		endPosition = 0;
 	}	
 	
 	@Override
 	public final void end() throws IOException {
         super.end();
 	    // set final offset
-		int finalOffset = correctOffset(this.endPosition);
+		int finalOffset = correctOffset(this.endPosition+ _IKImplement.getLastUselessCharNum());
 		offsetAtt.setOffset(finalOffset, finalOffset);
         posIncrAtt.setPositionIncrement(posIncrAtt.getPositionIncrement() + skippedPositions);
 	}


### PR DESCRIPTION
As the following simple case, IK analyzer responses with wrong offset fields compared with standard analyzer. 
//////////////////////////////////////////////////////////////////////////
GET iktest/_analyze
{
    "analyzer": "ik_max_word", 
    "text": ["hello, world~", "hello, ik!"]
}

{
  "tokens" : [
    {
      "token" : "hello",
      "start_offset" : 0,
      "end_offset" : 5,
      "type" : "ENGLISH",
      "position" : 0
    },
    {
      "token" : "world",
      "start_offset" : 7,
      "end_offset" : 12,
      "type" : "ENGLISH",
      "position" : 1
    },
    {
      "token" : "hello",
      "start_offset" : **13**,
      "end_offset" : **18**,
      "type" : "ENGLISH",
      "position" : 102
    },
    {
      "token" : "ik",
      "start_offset" : 20,
      "end_offset" : 22,
      "type" : "ENGLISH",
      "position" : 103
    }
  ]
}

//////////////////////////////////////////////////////////////////////////

GET iktest/_analyze
{
    "analyzer": "standard", 
    "text": ["hello, world~", "hello, ik!"]
}

{
  "tokens" : [
    {
      "token" : "hello",
      "start_offset" : 0,
      "end_offset" : 5,
      "type" : "<ALPHANUM>",
      "position" : 0
    },
    {
      "token" : "world",
      "start_offset" : 7,
      "end_offset" : 12,
      "type" : "<ALPHANUM>",
      "position" : 1
    },
    {
      "token" : "hello",
      "start_offset" : **14**,
      "end_offset" : **19**,
      "type" : "<ALPHANUM>",
      "position" : 102
    },
    {
      "token" : "ik",
      "start_offset" : 21,
      "end_offset" : 23,
      "type" : "<ALPHANUM>",
      "position" : 103
    }
  ]
}

//////////////////////////////////////////////////////////////////////////
We found that the problem was caused by the end of useless characters. IK analyzer does not calculate end of useless characters and set the wrong offset in "end" funtion.