### PR TITLE
change Lexeme.compareTo sorting rules: shorter term first

### DIFF
--- a/core/src/main/java/org/wltea/analyzer/core/Lexeme.java
+++ b/core/src/main/java/org/wltea/analyzer/core/Lexeme.java
@@ -120,11 +120,12 @@ public class Lexeme implements Comparable<Lexeme>{
             return -1;
         }else if(this.begin == other.getBegin()){
         	//词元长度优先
-        	if(this.length > other.getLength()){
+			//長度短的優先
+        	if(this.length < other.getLength()){
         		return -1;
         	}else if(this.length == other.getLength()){
         		return 0;
-        	}else {//this.length < other.getLength()
+        	}else {//this.length > other.getLength()
         		return 1;
         	}
         	


### PR DESCRIPTION
更改 Lexeme 詞元的排序方式，改成詞元短的優先，可以解決使用 ik_max_word 在某些情況下無法搜尋到文章的問題

文本：現在想要找一台車
match_phrase：現在想要
tokenizer：都是 ik_max_word

### 修改前

文本斷詞結果：

token | type | position | start_offset | end_offset
-- | -- | -- | -- | --
現在 | CN_WORD | 0 | 0 | 2
在想 | CN_WORD | 1 | 1 | 3
想要 | CN_WORD | 2 | 2 | 4
想 | CN_WORD | 3 | 2 | 3
要找 | CN_WORD | 4 | 3 | 5
要 | CN_WORD | 5 | 3 | 4
找 | CN_WORD | 6 | 4 | 5
一台 | CN_WORD | 7 | 5 | 7
一 | TYPE_CNUM | 8 | 5 | 6
台車 | CN_WORD | 9 | 6 | 8
台 | COUNT | 10 | 6 | 7
車 | CN_CHAR | 11 | 7 | 8

match_phrase 斷詞結果：

token | type | position | start_offset | end_offset
-- | -- | -- | -- | --
現在 | CN_WORD | 0 | 0 | 2
在想 | CN_WORD | 1 | 1 | 3
想要 | CN_WORD | 2 | 2 | 4
想 | CN_WORD | 3 | 2 | 3
要 | CN_WORD | 4 | 3 | 4

文本斷詞中「想」「要」中間多了一個「要找」，所以會搜尋不到

### 修改後

修改排序邏輯，讓「要」排在「要找」之前

文本斷詞結果：

token | type | position | start_offset | end_offset
-- | -- | -- | -- | --
現在 | CN_WORD | 0 | 0 | 2
在想 | CN_WORD | 1 | 1 | 3
想 | CN_WORD | 2 | 2 | 3
想要 | CN_WORD | 3 | 2 | 4
要 | CN_WORD | 4 | 3 | 4
要找 | CN_WORD | 5 | 3 | 5
找 | CN_WORD | 6 | 4 | 5
一 | TYPE_CNUM | 7 | 5 | 6
一台 | CN_WORD | 8 | 5 | 7
台 | COUNT | 9 | 6 | 7
台車 | CN_WORD | 10 | 6 | 8

match_phrase 斷詞結果：

token | type | position | start_offset | end_offset
-- | -- | -- | -- | --
現在 | CN_WORD | 0 | 0 | 2
在想 | CN_WORD | 1 | 1 | 3
想 | CN_WORD | 2 | 2 | 3
想要 | CN_WORD | 3 | 2 | 4
要 | CN_WORD | 4 | 3 | 4

這樣就可以正常搜尋到
