### PR TITLE
Fix#1155: token offset regression in detectRepeatedWords()

### DIFF
--- a/core/src/main/java/org/wltea/analyzer/core/IKArbitrator.java
+++ b/core/src/main/java/org/wltea/analyzer/core/IKArbitrator.java
@@ -130,7 +130,7 @@ class IKArbitrator {
 					if (remainLength > 0) {
 						// 创建一个表示剩余部分的词元
 						// offset 应该是第一个词元的 offset + 第一个词元的长度
-						int remainOffset = firstLexeme.getOffset() + firstLexeme.getLength();
+						int remainOffset = firstLexeme.getOffset();
 						Lexeme remainLexeme = new Lexeme(remainOffset, remainStart, remainLength, Lexeme.TYPE_CNCHAR);
 						simplifiedPath.addNotCrossLexeme(remainLexeme);
 					}


### PR DESCRIPTION
# Summary

#1155 Fix an incorrect offset calculation in IKArbitrator.detectRepeatedWords() that causes Lucene to throw illegal_argument_exception ("offsets must not go backwards") when indexing certain text under ik_smart mode.

# Problem

When a crossPath triggers the detectRepeatedWords safety valve (longLexemeCount > 5 or totalCount > 50), the synthetic remainder lexeme is constructed with an inflated offset:
int remainOffset = firstLexeme.getOffset() + firstLexeme.getLength(); // wrong
Since Lexeme.getBeginPosition() = offset + begin, this causes the remainder's start position to be shifted forward by firstLexeme.getLength() characters. If the inflated position exceeds the start of the next token after the crossPath, Lucene detects a non-monotonic startOffset and rejects the document.

# Fix

- int remainOffset = firstLexeme.getOffset() + firstLexeme.getLength();
- int remainOffset = firstLexeme.getOffset();
All lexemes within the same buffer must share the same offset (the buffer's absolute start position in the document). The remainder lexeme is in the same buffer as firstLexeme, so its offset should simply be firstLexeme.getOffset().

# Test

Using a custom dictionary with 6 overlapping words (each 11 chars, shifted by 2 chars):
```
这段文字用于测试分词器
文字用于测试分词器偏移
用于测试分词器偏移量计
测试分词器偏移量计算在
分词器偏移量计算在运行
器偏移量计算在运行过程
```
Restart OpenSearch cluster

Create a test index:
```
PUT /test_ik_offset_bug
{
  "settings": {
    "number_of_shards": 1,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "content": {
        "type": "text",
        "analyzer": "ik_smart"
      }
    }
  }
}
```
Index a triggering document:
```
PUT /test_ik_offset_bug/_doc/1
{
  "content": "这段文字用于测试分词器偏移量计算在运行过程后检验和确认结果"
}
```

Before fix: throws startOffset must be non-negative, and endOffset must be >= startOffset, and offsets must not go backwards

<img width="2514" height="438" alt="image" src="https://github.com/user-attachments/assets/98d3ffd3-19b6-4755-930e-ea7391609be2" />


After fix: returns tokens with strictly increasing offsets

<img width="1675" height="440" alt="image" src="https://github.com/user-attachments/assets/00066fc1-af2a-4f35-a830-24273d651538" />
